### PR TITLE
Update index_qlc.html

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ when you dont like the icon, color or title you can change it in the configurati
 
 ## Button actions
 You can assign a button action to the button. The button actions are:
-- `Simpe button` - your button is a simpe pushbutton that just sends a value when pressed
-- `Button with evebt on click and release` - your button sends a value when pressed and another value when released both values can be selected and enable some more functions for qlc+.
-- `Flashbutton` - the button sends the same value on click and release. this anables the flash function for chases in qlc+.
+- `Simple button` - your button is a simple pushbutton that just sends a value when pressed
+- `Button with evebt on click and release` - your button sends a value when pressed, and another value when released (both values can be selected and enable some more functions for qlc+)
+- `Flashbutton` - the button sends the same value on click and release (this anables the flash function for chases in qlc+)
+
+- Patch 1 modification by SiliconKnight42 in Dec24 - removed restriction on Values for button to be numeric.  By allowing any value, these Streamdeck buttons can now control QLC Playlists by using the "NEXT" and "PREV" commands; however, care must be taken by users to ensure that only numeric values are sent to other VC Widgets (e.g. buttons, faders, etc.).
+

--- a/com.qlc.QLC-connect.sdPlugin/index_qlc.html
+++ b/com.qlc.QLC-connect.sdPlugin/index_qlc.html
@@ -91,7 +91,7 @@
         </div>
         <div class="sdpi-item" id="valueSend">
             <div class="sdpi-item-label">Value</div>
-            <input class="sdpi-item-value" type="number" id="value" value="255" min="1"max="255" step="1">
+            <input class="sdpi-item-value" type="text" id="value" >
         </div>
         <div id="release-ev">
 
@@ -105,7 +105,7 @@
             </div>
             <div class="sdpi-item" id="valueSend2">
                 <div class="sdpi-item-label">Value</div>
-                <input class="sdpi-item-value" type="number" id="value" value="255" min="1"max="255" step="1">
+                <input class="sdpi-item-value" type="text" id="value">
             </div>
         </div>
 


### PR DESCRIPTION
Change Value field type to text and restrictions on input.  This will allow this plug-in to be used for Cue lists (where the value needs to be PLAY, NEXT, or PREV).  Further edits will be required to support the STEP command.